### PR TITLE
fix: All these imports are only used as types.

### DIFF
--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -1,5 +1,5 @@
 ---
-import { type HTMLAttributes } from "astro/types";
+import type { HTMLAttributes } from "astro/types";
 
 const headingOptions = {
   h1: "xxl",


### PR DESCRIPTION
ref: https://biomejs.dev/linter/rules/use-import-type/

![Screenshot 2024-09-19 at 1 47 35 PM](https://github.com/user-attachments/assets/fa803531-c7d1-4075-ba33-045eba17cf75)


From the ref: 

Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
  
  Safe fix: Use import type.

```git 
  1     │ - import·{·type·A,·type·B·}·from·“./mod.js”;
  1     │ + import·type·{·A,·B·}·from·“./mod.js”;
```